### PR TITLE
Add MockOperationContext#derive API

### DIFF
--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.1.0
+
+- #83 Add MockOperationContext#derive API

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -16,5 +16,8 @@
     "jest": "24.8.0",
     "ts-jest": "24.0.2",
     "typescript": "3.5.3"
+  },
+  "dependencies": {
+    "immer": "^3.2.0"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleur/test-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/index.js",
   "types": "typings/index.d.ts",
   "author": "Ragg<ragg.devpr@gmail.com>",

--- a/packages/test-utils/src/__snapshots__/mockStore.spec.ts.snap
+++ b/packages/test-utils/src/__snapshots__/mockStore.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`mockStoreContext Should create Store entry correctly 1`] = `
 Object {
+  "StoreClass": [Function],
   "name": "SomeStore",
   "store": SomeStore {
     "context": StoreContext {

--- a/packages/test-utils/src/mockOperationContext.spec.ts
+++ b/packages/test-utils/src/mockOperationContext.spec.ts
@@ -49,20 +49,20 @@ describe('mockOperationContext', () => {
   })
 
   it('Example', async () => {
-    // Spec
-    await baseContext.executeOperation(increaseOp, 100)
+    const context = baseContext.derive()
+    await context.executeOperation(increaseOp, 100)
 
-    expect(baseContext.dispatchs[0]).toMatchObject({
+    expect(context.dispatchs[0]).toMatchObject({
       action: resetAction,
       payload: {},
     })
 
-    expect(baseContext.dispatchs[1]).toMatchObject({
+    expect(context.dispatchs[1]).toMatchObject({
       action: increaseAction,
       payload: { increase: 100 },
     })
 
-    expect(baseContext.getStore(CountStore).count).toBe(100)
+    expect(context.getStore(CountStore).count).toBe(100)
   })
 
   it('Derive store state', () => {

--- a/packages/test-utils/src/mockOperationContext.spec.ts
+++ b/packages/test-utils/src/mockOperationContext.spec.ts
@@ -3,55 +3,81 @@ import { mockOperationContext } from './mockOperationContext'
 import { mockStore } from './mockStore'
 
 describe('mockOperationContext', () => {
-  it('Example', async () => {
-    // Actions.ts
-    const resetAction = action<{}>()
-    const increaseAction = action<{ increase: number }>()
+  //
+  // Actions.ts
+  //
+  const resetAction = action<{}>()
+  const increaseAction = action<{ increase: number }>()
 
-    // CountStore.ts
-    class CountStore extends Store<{ count: number }> {
-      public static storeName = 'CountStore'
+  //
+  // CountStore.ts
+  //
+  class CountStore extends Store<{ count: number }> {
+    public static storeName = 'CountStore'
 
-      protected state = { count: 0 }
+    public state = { count: 0 }
 
-      private resetCount = listen(resetAction, () =>
-        this.updateWith(state => (state.count = 0)),
-      )
+    private resetCount = listen(resetAction, () =>
+      this.updateWith(state => (state.count = 0)),
+    )
 
-      private increaseCount = listen(increaseAction, payload =>
-        this.updateWith(state => (state.count += payload.increase)),
-      )
-      getCount() {
-        return this.state.count
-      }
+    private increaseCount = listen(increaseAction, payload =>
+      this.updateWith(state => (state.count += payload.increase)),
+    )
+
+    get count() {
+      return this.state.count
     }
+  }
 
-    // Operations.ts
-    const resetCountOp = operation(context => {
-      context.dispatch(resetAction, {})
-    })
-    const increaseOp = operation(async (context, increase: number) => {
-      await context.executeOperation(resetCountOp)
-      context.dispatch(increaseAction, { increase })
-    })
+  //
+  // Operations.ts
+  //
+  const resetCountOp = operation(context => {
+    context.dispatch(resetAction, {})
+  })
+  const increaseOp = operation(async (context, increase: number) => {
+    await context.executeOperation(resetCountOp)
+    context.dispatch(increaseAction, { increase })
+  })
 
-    const context = mockOperationContext({
-      stores: [mockStore(CountStore, { count: 100 })],
-    })
+  //
+  // spec/baseMock.ts
+  //
+  const baseContext = mockOperationContext({
+    stores: [mockStore(CountStore, { count: 100 })],
+  })
 
+  it('Example', async () => {
     // Spec
-    await context.executeOperation(increaseOp, 100)
+    await baseContext.executeOperation(increaseOp, 100)
 
-    expect(context.dispatchs[0]).toMatchObject({
+    expect(baseContext.dispatchs[0]).toMatchObject({
       action: resetAction,
       payload: {},
     })
 
-    expect(context.dispatchs[1]).toMatchObject({
+    expect(baseContext.dispatchs[1]).toMatchObject({
       action: increaseAction,
       payload: { increase: 100 },
     })
 
-    expect(context.getStore(CountStore).getCount()).toBe(100)
+    expect(baseContext.getStore(CountStore).count).toBe(100)
+  })
+
+  it('Derive store state', () => {
+    const derivedContext = baseContext.derive(({ deriveStore }) => {
+      deriveStore(CountStore, state => {
+        state.count = 10
+      })
+    })
+
+    const derivedContext2 = baseContext.derive(({ deriveStore }) => {
+      deriveStore(CountStore, { count: 20 })
+    })
+
+    expect(baseContext.getStore(CountStore).count).toBe(100)
+    expect(derivedContext.getStore(CountStore).count).toBe(10)
+    expect(derivedContext2.getStore(CountStore).count).toBe(20)
   })
 })

--- a/packages/test-utils/src/mockOperationContext.ts
+++ b/packages/test-utils/src/mockOperationContext.ts
@@ -62,7 +62,7 @@ export class MockOperationContext {
   }
 
   public derive(
-    modifier: ({ deriveStore: derive }: { deriveStore: StoreDeriver }) => void,
+    modifier?: ({ deriveStore: derive }: { deriveStore: StoreDeriver }) => void,
   ): MockOperationContext {
     const cloneStores = this.stores.map(entry =>
       mockStore(entry.StoreClass, entry.store.state),
@@ -87,7 +87,9 @@ export class MockOperationContext {
         }
       }
 
-      modifier({ deriveStore: storeDeriver })
+      if (modifier) {
+        modifier({ deriveStore: storeDeriver })
+      }
     })
 
     return new MockOperationContext(stores)

--- a/packages/test-utils/src/mockStore.spec.ts
+++ b/packages/test-utils/src/mockStore.spec.ts
@@ -1,5 +1,6 @@
 import { mockStore } from './mockStore'
 import { Store } from '@fleur/fleur'
+import { mockOperationContext } from './mockOperationContext'
 
 describe('mockStoreContext', () => {
   it('Should create Store entry correctly', () => {
@@ -7,9 +8,6 @@ describe('mockStoreContext', () => {
       static storeName = 'SomeStore'
       public state = { state: '' }
     }
-
-    const mockSomeStore = (state: State) =>
-      mockStore(SomeStore, { state: 'defaultMockState', ...state })
 
     const actual = mockStore(SomeStore, { state: 'mock' })
     expect(actual).toMatchSnapshot()

--- a/packages/test-utils/src/mockStore.ts
+++ b/packages/test-utils/src/mockStore.ts
@@ -6,6 +6,7 @@ type ExtractStateType<T extends Store> = T extends Store<infer S> ? S : never
 export interface MockStore {
   name: string
   store: Store<any>
+  StoreClass: StoreClass<any>
 }
 
 export const mockStore = <S extends StoreClass>(
@@ -14,5 +15,5 @@ export const mockStore = <S extends StoreClass>(
 ): MockStore => {
   const store = new StoreClass(mockStoreContext())
   Object.assign((store as any).state, partialState)
-  return { name: StoreClass.storeName, store }
+  return { name: StoreClass.storeName, store, StoreClass }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,6 +2826,11 @@ immer@^3.1.3:
   resolved "https://registry.yarnpkg.com/immer/-/immer-3.1.3.tgz#59bc742b2aab6e2c676445edb653e588a23c70fc"
   integrity sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ==
 
+immer@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-3.2.0.tgz#53686471e9dd2b070e0fb5500c6fdecd3a99375f"
+  integrity sha512-+a2R8z9eELHst6aht++nzVzJ8LJ+Hsg49qttfg9Kc/vmoxEdPXw5/rV6+4DYWGgnq+B36KbLr4OTaGtS9mDjtg==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,11 @@ bluebird@^3.5.0, bluebird@^3.5.3:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
 
+bluebird@^3.5.1:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -1624,6 +1629,15 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -1713,7 +1727,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.2.0:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -2077,6 +2091,19 @@ exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -2324,6 +2351,13 @@ find-cache-dir@^3.0.0:
     make-dir "^3.0.0"
     pkg-dir "^4.1.0"
 
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -2482,6 +2516,11 @@ get-stdin@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -2894,6 +2933,11 @@ invariant@^2.2.4:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -3650,6 +3694,13 @@ kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
+  dependencies:
+    invert-kv "^1.0.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -3756,6 +3807,14 @@ loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -3775,7 +3834,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3808,6 +3867,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.4
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3873,6 +3940,13 @@ md5.js@^1.3.4:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 mem@^4.0.0:
   version "4.3.0"
@@ -4378,6 +4452,15 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
 os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
@@ -4421,12 +4504,26 @@ p-is-promise@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
   dependencies:
     p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -4450,6 +4547,11 @@ p-map@^2.0.0:
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -4694,6 +4796,11 @@ proxy-addr@~2.0.5:
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
   version "1.1.29"
@@ -5380,6 +5487,13 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5623,7 +5737,7 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
-throat@^4.0.0:
+throat@^4.0.0, throat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
@@ -5633,6 +5747,11 @@ through2@^2.0.0:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timers-browserify@^2.0.4:
   version "2.0.10"
@@ -6155,6 +6274,20 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
+wsrun@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/wsrun/-/wsrun-5.0.0.tgz#9b086bfdf04de98be84c73057fd8f42dc36d5c59"
+  integrity sha512-xv3uBTZZqmtmQumR+67S8oJ0zr4sfSbOvs+L7OdNbwUj1XYBX91Kx0Wbm3gpjkn0PKBuCKf3z62DdjO7/+bVKg==
+  dependencies:
+    bluebird "^3.5.1"
+    chalk "^2.3.0"
+    glob "^7.1.2"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    split "^1.0.1"
+    throat "^4.1.0"
+    yargs "^10.0.3"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -6163,9 +6296,19 @@ xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
@@ -6192,6 +6335,13 @@ yargs-parser@^13.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@13.2.4:
   version "13.2.4"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
@@ -6208,6 +6358,24 @@ yargs@13.2.4:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^12.0.2:
   version "12.0.5"


### PR DESCRIPTION
テスト時に基底の状態から特定のテストケースのためにStoreの差分変更を行いやすいAPIを追加した。というかテストする時にderiveないとdispatchsがハチャメチャになるやんけ…（今気づいた）

```typescript
// spec/mocks.ts - Base mock stores for testing
const MockAppStore = mockStore(AppStore, { initialized: false })

export const mockContext = mockOperationContext({
  stores: [ MockAppStore ],
})

// src/operations.ts
export const Ops = operations({
  foo(context) {
    const { initialized } = context.getStore(AppStore).state
    if (initialized) {
      context.dispatch(Actions.initialized, {})
    } else {
      context.dispatch(Actions.loading, {})
    }
  }
})

// src/operations.spec.ts
import { AppStore } from 'stores/AppStore'
import { mockContext } from 'spec/mocks'

describe('Ops', () => {
  it('on initialized', async () => {
    const context = mockContext.derive(({ deriveStore }) => deriveStore(AppStore, { initialized: true })
    await context.executeOperation(Ops.foo)
    expect(context.dispatchs[0]).toMatchObject({ action: Actions.initialized })
  })

  it('before initialized', async () => {
    const context = mockContext.derive(({ deriveStore }) => deriveStore(AppStore, { initialized: false })
    await context.executeOperation(Ops.foo)
    expect(context.dispatchs[0]).toMatchObject({ action: Actions.loading })
  })
})
